### PR TITLE
Enable GitHub Actions for testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout
+        uses: actions/checkout@v3
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout
+        uses: actions/checkout@v3
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Tests


### PR DESCRIPTION
This PR enables GitHub Actions for CI. It does the following:

* Runs typechecks, lints, and tests
* Tests are executed on Linux, MacOS, and Windows