### PR TITLE
Reduce time spent in Github Actions

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -44,6 +44,9 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   is-release:
     needs: [lint, test]
+    # Avoid as many job runs as possible with `if`
+    # due to billing rounding up to the minute.
+    if: github.event_name == 'push'
     outputs:
       result: ${{ steps.is-release.outputs.result }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoid unnecessary billed minutes by reducing time spent in CI (GitHub Actions).

* Use caches in PRs
* Avoid *is release?* jobs running in the first place on PRs