### PR TITLE
Update OpenAI API usage to newest version

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -1,11 +1,12 @@
 /// OpenAI Model
 ///
-/// Defaulted to the latest Codex model,
-/// optimized by OpenAI for code.
+/// Default to the latest, universally
+/// accessible model by OpenAI for code
+/// generation.
 ///
 /// https://platform.openai.com/docs/models/models
 ///
-pub const OPENAI_MODEL: &str = "code-davinci-002";
+pub const OPENAI_MODEL: &str = "gpt-3.5-turbo";
 
 /// Model Temperature
 ///


### PR DESCRIPTION
OpenAI has deprecated the "Codex" suite of models. The GPT-* chat models are recommended as the replacement.